### PR TITLE
Fix isDev check

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ yarn add next-safe
 ```js
 const nextSafe = require('next-safe')
 
-const isDev = process.env.NODE_ENV === 'production'
+const isDev = process.env.NODE_ENV !== 'production'
 
 module.exports = {
 	async headers () {


### PR DESCRIPTION
When copying the configuration I noticed a small typo which leads to using the dev configuration in production and vice verca.