### PR TITLE
Fix missing types declaration file

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
   "types": "types/types.d.ts",
   "scripts": {
     "build-types": "jsdoc -t node_modules/tsd-jsdoc/dist -r lib/. -d types",
-    "test": "jest",
-    "semantic-release": "semantic-release"
+    "prepublish": "yarn build-types",
+    "semantic-release": "semantic-release",
+    "test": "jest"
   },
   "peerDependencies": {
     "next": "^9.5.0 || ^10.2.1 || ^11.1.0"


### PR DESCRIPTION
The `build-types` Yarn script exists, but it's unused. This PR adds `yarn build-types` to the `prepublish` script so it'll be run whenever `semantic-release` releases a new version of the library.

Fixes #30