### PR TITLE
Chore - Add next 12 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "next": "^9.5.0 || ^10.2.1 || ^11.1.0"
+    "next": "^9.5.0 || ^10.2.1 || ^11.1.0 || ^12.1.0"
   },
   "devDependencies": {
     "jest": "^26.6.3",


### PR DESCRIPTION
Addressing the bug described in this issue: https://github.com/trezy/next-safe/issues/39.

This should require no changes to how the module works but will simply allow it to be installed for users already on Next.js 12. 

Let me know if this makes sense or whether a more in-depth explanation is needed🙏 