### PR TITLE
fix(buildCSPHeaders): remove 'none' when appropriate

### DIFF
--- a/lib/buildCSPHeaders.js
+++ b/lib/buildCSPHeaders.js
@@ -34,8 +34,13 @@ function getCSPDirective(value, defaultValue, mergeDefaultDirectives = false) {
 	// de-duplicate merged values
 	const uniqueValueArray = [...new Set(mergedValueArray)]
 
+	// remove value "'none'" if the array contains other values
+	const validValueArray = uniqueValueArray.length > 1
+		? uniqueValueArray.filter((v) => v !== "'none'")
+		: uniqueValueArray
+
 	// only return user configured values if present, otherwise return default
-	return uniqueValueArray.length > 0 ? uniqueValueArray : defaultValueArray
+	return validValueArray.length > 0 ? validValueArray : defaultValueArray
 }
 
 module.exports = function buildCSPHeaders(options = {}) {


### PR DESCRIPTION
The value 'none' should not be mixed with other CSP values. This change removes the value 'none' if there is more than one value present in any directive.