### PR TITLE
fix: ensure that the dist file structure is correct

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,8 @@
     "moduleResolution": "node",
     "stripInternal": true,
     "outDir": "./dist"
-  }
+  },
+  "files": [
+    "./src/index.ts"
+  ]
 }


### PR DESCRIPTION
The `dist` directory in 4.0.0-beta.1 release is incorrectly structured. This change to `tsconfig.json` ensures that there is an `index.js` at the root of the `dist` directory, along with associated `lib`, `models`, and `types`.