### PR TITLE
fix: Remove deprecated CSP: prefetch-src option

### DIFF
--- a/__tests__/buildCSPHeaders.js
+++ b/__tests__/buildCSPHeaders.js
@@ -19,7 +19,6 @@ const DEFAULT_CSP = {
 	'manifest-src': '\'self\'',
 	'media-src': '\'self\'',
 	'object-src': '\'none\'',
-	'prefetch-src': '\'self\'',
 	'script-src': '\'self\'',
 	'style-src': '\'self\'',
 	'worker-src': '\'self\'',

--- a/docs/api/contentSecurityPolicy.md
+++ b/docs/api/contentSecurityPolicy.md
@@ -17,7 +17,6 @@
 		"manifest-src": "'self'",
 		"media-src": "'self'",
 		"object-src": "'none'",
-		"prefetch-src": "'self'",
 		"script-src": "'self'",
 		"style-src": "'self'",
 		"worker-src": "'self'",
@@ -79,16 +78,6 @@ Note that `'self'` is in quotes. This is a CSP thing and `next-safe` does not ha
 {
 	contentSecurityPolicy: {
 		"upgrade-insecure-requests": [],
-	},
-}
-```
-
-#### Disable the `prefetch-src` directive
-
-```js
-{
-	contentSecurityPolicy: {
-		"prefetch-src": false,
 	},
 }
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,7 +18,6 @@ nextSafe({
 		"manifest-src": "'self'",
 		"media-src": "'self'",
 		"object-src": "'none'",
-		"prefetch-src": "'self'",
 		"script-src": "'self'",
 		"style-src": "'self'",
 		"worker-src": "'self'",

--- a/lib/buildCSPHeaders.js
+++ b/lib/buildCSPHeaders.js
@@ -70,7 +70,6 @@ module.exports = function buildCSPHeaders(options = {}) {
 		'manifest-src': getCSPDirective(contentSecurityPolicy['manifest-src'], "'self'", mergeDefaultDirectives),
 		'media-src': getCSPDirective(contentSecurityPolicy['media-src'], "'self'", mergeDefaultDirectives),
 		'object-src': getCSPDirective(contentSecurityPolicy['object-src'], "'none'", mergeDefaultDirectives),
-		'prefetch-src': getCSPDirective(contentSecurityPolicy['prefetch-src'], "'self'", mergeDefaultDirectives),
 		'script-src': getCSPDirective(contentSecurityPolicy['script-src'], "'self'", mergeDefaultDirectives),
 		'style-src': getCSPDirective(contentSecurityPolicy['style-src'], "'self'", mergeDefaultDirectives),
 		'worker-src': getCSPDirective(contentSecurityPolicy['worker-src'], "'self'", mergeDefaultDirectives),

--- a/lib/models/CSP.js
+++ b/lib/models/CSP.js
@@ -20,7 +20,6 @@
  * @property {CSPDirective} ['manifest-src']
  * @property {CSPDirective} ['media-src']
  * @property {CSPDirective} ['object-src']
- * @property {CSPDirective} ['prefetch-src']
  * @property {CSPDirective} ['script-src']
  * @property {CSPDirective} ['style-src']
  * @property {CSPDirective} ['worker-src']


### PR DESCRIPTION
The CSP: `prefetch-src` option [is deprecated](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/prefetch-src) and [no longer supported by any browsers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/prefetch-src#browser_compatibility) (with the exception of Safari on iOS).

This PR removes it from the CSP headers.